### PR TITLE
Add useWrapMode Ace option; fix some comments

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.3.0",
+    "version": "2.4.0",
     "summary": "Ace editor component",
     "repository": "https://github.com/DenisKolodin/elm-ace.git",
     "license": "BSD3",

--- a/examples/Editor.elm
+++ b/examples/Editor.elm
@@ -1,32 +1,39 @@
-{- This app is the basic Ace editor app.
--}
+{- This app is the basic Ace editor app. -}
 
-import Html exposing (..)
-import Html
-import Html.Events exposing (..)
+
+module Main exposing (..)
+
 import Ace
+import Html exposing (..)
+import Html.Events exposing (..)
+
 
 main =
-  Html.program
-    { init = init
-    , subscriptions = subscriptions
-    , update = update
-    , view = view
-    }
+    Html.program
+        { init = init
+        , subscriptions = subscriptions
+        , update = update
+        , view = view
+        }
+
+
 
 -- MODEL
 
 
 type alias Model =
-  { source: String
-  , theme: String
-  }
+    { source : String
+    , theme : String
+    }
 
-blankSource = "-- It's a source!\nlocal x = 1"
 
-init : (Model, Cmd Msg)
+blankSource =
+    "-- It's a source!\nlocal x = 1"
+
+
+init : ( Model, Cmd Msg )
 init =
-  ({ source = blankSource, theme = "ambiance" }, Cmd.none)
+    ( { source = blankSource, theme = "ambiance" }, Cmd.none )
 
 
 
@@ -34,22 +41,23 @@ init =
 
 
 type Msg
-  = UpdateSource String
-  | SetThemeTo String
+    = UpdateSource String
+    | SetThemeTo String
 
 
-update : Msg -> Model -> (Model, Cmd Msg)
+update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
-  let
-    newModel =
-      case msg of
-        UpdateSource source ->
-          { model | source = source }
-        SetThemeTo theme ->
-          { model | theme = theme }
+    let
+        newModel =
+            case msg of
+                UpdateSource source ->
+                    { model | source = source }
 
-  in
-    (newModel, Cmd.none)
+                SetThemeTo theme ->
+                    { model | theme = theme }
+    in
+    ( newModel, Cmd.none )
+
 
 
 -- SUBSCRIPTIONS
@@ -57,30 +65,32 @@ update msg model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-  Sub.none
+    Sub.none
 
 
 
 -- VIEW
 
+
 view : Model -> Html Msg
 view model =
-  div []
-    [ Ace.toHtml
-      [ Ace.onSourceChange UpdateSource
-      , Ace.value model.source
-      , Ace.mode "lua"
-      , Ace.theme model.theme
-      , Ace.enableBasicAutocompletion True
-      , Ace.enableLiveAutocompletion True
-      , Ace.enableSnippets True
-      , Ace.tabSize 2
-      , Ace.useSoftTabs False
-      , Ace.extensions [ "language_tools" ]
-      ] []
-    , Html.button [ onClick (SetThemeTo "monokai") ] [ Html.text "Set 'monokai' theme" ]
-    , Html.button [ onClick (SetThemeTo "cobalt") ] [ Html.text "Set 'cobalt' theme" ]
-    , Html.button [ onClick (SetThemeTo "ambiance") ] [ Html.text "Revert 'ambiance' theme" ]
-    , Html.button [ onClick (UpdateSource blankSource) ] [ Html.text "Reset source" ]
-    , Html.text model.source
-    ]
+    div []
+        [ Ace.toHtml
+            [ Ace.onSourceChange UpdateSource
+            , Ace.value model.source
+            , Ace.mode "lua"
+            , Ace.theme model.theme
+            , Ace.enableBasicAutocompletion True
+            , Ace.enableLiveAutocompletion True
+            , Ace.enableSnippets True
+            , Ace.tabSize 2
+            , Ace.useSoftTabs False
+            , Ace.extensions [ "language_tools" ]
+            ]
+            []
+        , Html.button [ onClick (SetThemeTo "monokai") ] [ Html.text "Set 'monokai' theme" ]
+        , Html.button [ onClick (SetThemeTo "cobalt") ] [ Html.text "Set 'cobalt' theme" ]
+        , Html.button [ onClick (SetThemeTo "ambiance") ] [ Html.text "Revert 'ambiance' theme" ]
+        , Html.button [ onClick (UpdateSource blankSource) ] [ Html.text "Reset source" ]
+        , Html.text model.source
+        ]

--- a/src/Ace.elm
+++ b/src/Ace.elm
@@ -2,30 +2,37 @@ module Ace exposing (..)
 
 {-| A library to use Ace editor with Elm.
 
+
 # Editor
+
 @docs toHtml
 
+
 # Ace's Attributes
+
 @docs theme, readOnly, mode, value, highlightActiveLine
 @docs showPrintMargin, showCursor, showGutter, tabSize, useSoftTabs
 @docs enableBasicAutocompletion, enableLiveAutocompletion, enableSnippets, extensions
 
+
 # Ace's Events
+
 @docs onSourceChange
 
 -}
 
-import Html exposing (Html, Attribute)
+import Html exposing (Attribute, Html)
 import Html.Attributes as Attributes
 import Html.Events as Events
-import Json.Encode as JE
 import Json.Decode as JD
+import Json.Encode as JE
 import Native.Ace
 
 
 {-| Attribute to set the theme to Ace.
 
     Ace.toHtml [ Ace.theme "monokai" ] []
+
 -}
 theme : String -> Attribute msg
 theme val =
@@ -35,6 +42,7 @@ theme val =
 {-| Attribute to set editor in readonly.
 
     Ace.toHtml [ Ace.readOnly true ] []
+
 -}
 readOnly : Bool -> Attribute msg
 readOnly val =
@@ -44,6 +52,7 @@ readOnly val =
 {-| Attribute to set the mode to Ace.
 
     Ace.toHtml [ Ace.mode "lua" ] []
+
 -}
 mode : String -> Attribute msg
 mode val =
@@ -53,6 +62,7 @@ mode val =
 {-| Attribute to set initial value or to update current value of Ace.
 
     Ace.toHtml [ Ace.value "lua" ] []
+
 -}
 value : String -> Attribute msg
 value val =
@@ -62,6 +72,7 @@ value val =
 {-| Attribute to set whether to show the print margin or not.
 
     Ace.toHtml [ Ace.showPrintMargin false ] []
+
 -}
 showPrintMargin : Bool -> Attribute msg
 showPrintMargin val =
@@ -71,6 +82,7 @@ showPrintMargin val =
 {-| Attribute to set whether show cursor or not
 
     Ace.toHtml [ Ace.showCursor false ] []
+
 -}
 showCursor : Bool -> Attribute msg
 showCursor val =
@@ -80,6 +92,7 @@ showCursor val =
 {-| Attribute to set whether to show gutter or not.
 
     Ace.toHtml [ Ace.showGutter false ] []
+
 -}
 showGutter : Bool -> Attribute msg
 showGutter val =
@@ -89,6 +102,7 @@ showGutter val =
 {-| Attribute to set whether to highlight the active line or not.
 
     Ace.toHtml [ Ace.highlightActiveLine false ] []
+
 -}
 highlightActiveLine : Bool -> Attribute msg
 highlightActiveLine val =
@@ -98,6 +112,7 @@ highlightActiveLine val =
 {-| Attribute to set whether to use soft tabs or not.
 
     Ace.toHtml [ Ace.useSoftTabs false ] []
+
 -}
 tabSize : Int -> Attribute msg
 tabSize val =
@@ -107,6 +122,7 @@ tabSize val =
 {-| Attribute to set whether to use soft tabs or not.
 
     Ace.toHtml [ Ace.useSoftTabs false ] []
+
 -}
 useSoftTabs : Bool -> Attribute msg
 useSoftTabs val =
@@ -116,6 +132,7 @@ useSoftTabs val =
 {-| Attribute to set autocompletion option.
 
     Ace.toHtml [ Ace.enableBasicAutocompletion true ] []
+
 -}
 enableBasicAutocompletion : Bool -> Attribute msg
 enableBasicAutocompletion val =
@@ -125,6 +142,7 @@ enableBasicAutocompletion val =
 {-| Attribute to set live autocompletion option.
 
     Ace.toHtml [ Ace.enableLiveAutocompletion true ] []
+
 -}
 enableLiveAutocompletion : Bool -> Attribute msg
 enableLiveAutocompletion val =
@@ -134,6 +152,7 @@ enableLiveAutocompletion val =
 {-| Attribute to activate snippets.
 
     Ace.toHtml [ Ace.enableSnippets true ] []
+
 -}
 enableSnippets : Bool -> Attribute msg
 enableSnippets val =
@@ -143,6 +162,7 @@ enableSnippets val =
 {-| Set list of extensions for ace.
 
     Ace.toHtml [ Ace.extensions [ "language_tools" ] ] []
+
 -}
 extensions : List String -> Attribute msg
 extensions exts =
@@ -152,6 +172,7 @@ extensions exts =
 {-| Values changes listener. It used to get notifications about changes made by user.
 
     Ace.toHtml [ Ace.onSourceChange model.data ] []
+
 -}
 onSourceChange : (String -> msg) -> Attribute msg
 onSourceChange tagger =
@@ -161,6 +182,7 @@ onSourceChange tagger =
 {-| Creates `Html` instance with Ace attached to it.
 
     Ace.toHtml [] []
+
 -}
 toHtml : List (Attribute msg) -> List (Html msg) -> Html msg
 toHtml =

--- a/src/Ace.elm
+++ b/src/Ace.elm
@@ -11,7 +11,7 @@ module Ace exposing (..)
 # Ace's Attributes
 
 @docs theme, readOnly, mode, value, highlightActiveLine
-@docs showPrintMargin, showCursor, showGutter, tabSize, useSoftTabs
+@docs showPrintMargin, showCursor, showGutter, tabSize, useSoftTabs, useWrapMode
 @docs enableBasicAutocompletion, enableLiveAutocompletion, enableSnippets, extensions
 
 
@@ -127,6 +127,16 @@ tabSize val =
 useSoftTabs : Bool -> Attribute msg
 useSoftTabs val =
     Attributes.property "AceUseSoftTabs" (JE.bool val)
+
+
+{-| Attribute to set whether to use soft tabs or not.
+
+    Ace.toHtml [ Ace.useWrapMode false ] []
+
+-}
+useWrapMode : Bool -> Attribute msg
+useWrapMode val =
+    Attributes.property "AceUseWrapMode" (JE.bool val)
 
 
 {-| Attribute to set autocompletion option.

--- a/src/Ace.elm
+++ b/src/Ace.elm
@@ -61,7 +61,7 @@ mode val =
 
 {-| Attribute to set initial value or to update current value of Ace.
 
-    Ace.toHtml [ Ace.value "lua" ] []
+    Ace.toHtml [ Ace.value "-- It's a source!\nlocal x = 1" ] []
 
 -}
 value : String -> Attribute msg
@@ -111,7 +111,7 @@ highlightActiveLine val =
 
 {-| Attribute to set whether to use soft tabs or not.
 
-    Ace.toHtml [ Ace.useSoftTabs false ] []
+    Ace.toHtml [ Ace.tabSize 4 ] []
 
 -}
 tabSize : Int -> Attribute msg

--- a/src/Ace.elm
+++ b/src/Ace.elm
@@ -109,7 +109,7 @@ highlightActiveLine val =
     Attributes.property "AceHighlightActiveLine" (JE.bool val)
 
 
-{-| Attribute to set whether to use soft tabs or not.
+{-| Attribute to set the tab size.
 
     Ace.toHtml [ Ace.tabSize 4 ] []
 
@@ -129,7 +129,7 @@ useSoftTabs val =
     Attributes.property "AceUseSoftTabs" (JE.bool val)
 
 
-{-| Attribute to set whether to use soft tabs or not.
+{-| Attribute to set whether to use wrap mode.
 
     Ace.toHtml [ Ace.useWrapMode false ] []
 

--- a/src/Native/Ace.js
+++ b/src/Native/Ace.js
@@ -45,6 +45,7 @@ function emptyModel() {
         highlightActiveLine: true,
         tabSize: 4,
         useSoftTabs: true,
+        useWrapMode: false,
         readOnly: false,
         showCursor: true,
         showGutter: true,
@@ -79,6 +80,9 @@ function extractModel(factList) {
                 break;
             case "AceUseSoftTabs":
                 model.useSoftTabs = payload.value;
+                break;
+            case "AceUseWrapMode":
+                model.useWrapMode = payload.value;
                 break;
             case "AceReadOnly":
                 model.readOnly = payload.value;
@@ -155,6 +159,7 @@ function render(model) {
         editor.renderer.$cursorLayer.element.style.display = "none"
     editor.getSession().setTabSize(model.tabSize);
     editor.getSession().setUseSoftTabs(model.useSoftTabs);
+    editor.getSession().setUseWrapMode(model.useWrapMode);
     editor.getSession().setValue(model.value || "");
     var dummy = emptyModel();
     dummy.shared = shared;


### PR DESCRIPTION
Thanks for your work on this! It has made it super-simple to add Ace to my latest Elm project.

I needed just one extra option to soft-wrap lines (for large chunks of text-heavy html), so I've added it and thought I'd share this back in case anyone else might want it.

There are a couple of other things included, too:
- I made some changes to comment lines that appear to have been copy/pasted for new functions but left unchanged.
- Finally, I'm not sure how you might feel about this one, but I have [elm-format](https://github.com/avh4/elm-format#elm-format) auto-applied to .elm files on my machine. This accounts for all the whitespace changes, and a couple of rearrangements (elm-format alphabetizes package names). I decided to leave the formatting changes but haven't intended to be rude in doing so.